### PR TITLE
fix parse error of Signal Strength on Ubuntu12.04

### DIFF
--- a/lib/wifi_location.js
+++ b/lib/wifi_location.js
@@ -95,15 +95,16 @@ function parseIwlistOutput(text) {
         var k = null
         i.split('\n').forEach(function(j) {
             var rr = j.match(/Address: (.+)/)
-            var rrSignal = j.match(/Quality:(.+)  Signal level:(.+)  Noise level:(.+)/)
             if (rr) {
                 r.Address = rr[1].trim()
             }
-            else if (rrSignal) {
-                r.Quality = rrSignal[1].trim()
-                r['Signal level'] = rrSignal[2].trim()
-                r['Noise level'] = rrSignal[3].trim()
-            }
+	    else if (j.match(/Quality.+Signal level/)){
+		var rrSignal = j.match(/Quality[:=](.+)\s+Signal level[:=](.+)/)
+		r.Quality = rrSignal[1].trim()
+		r['Signal level'] = rrSignal[2].trim()
+		var rrSignalNoise = j.match(/Noise level[:=](.+)/)
+		if(rrSignalNoise) r['Noise level'] = rrSignalNoise[1].trim()
+	    }
             else {
                 var tmp = j.split(':')
                 if (tmp.length == 2) {


### PR DESCRIPTION
# 概要

うちの環境でSignal levelが取れていなかったので、function parseIwlistOutputを修正しました。
Noise levelが無かったり、区切り記号が:ではなく=の時も動作するようにしました。
Signal levelが無くてもそれなりに位置が取れてましたが、あるともっと精度上がります。
# 詳細

環境はUbuntu12.04+Node0.6.19です。
iwlist wlan0 scanすると、

```
Quality=58/70  Signal level=-52 dBm
```

が出ました。
parseIwlistOutputは

```
Quality:1/5  Signal level:-86 dBm  Noise level:-92 dBm
```

という形式でparseしているので、どちらの形式でもparseできるようにしました。

一応テストコードはこれです
https://gist.github.com/3313185

![よろしくおねがいします](http://xn--y8jp0mua.tiqav.com/)

あと、Macでは動きました。
